### PR TITLE
Added forward slash before query parameter in generated eventcal URL

### DIFF
--- a/app/index.php
+++ b/app/index.php
@@ -88,7 +88,7 @@ require_once('app.php');
 
         $form.find('input').on('input', function () {
             var cal = $("#fb-calendar").val().trim();
-            var domain = 'webcal://' + window.location.host + '?calendar=';
+            var domain = 'webcal://' + window.location.host + '/?calendar=';
             $filteredCal.val(domain + encodeURIComponent(cal));
         });
 


### PR DESCRIPTION
This is needed for compatibility with CalDAV-Sync for Android and possibly other 'strict' Webcal-Clients