### PR TITLE
Restrict to Facebook's calendar URLs

### DIFF
--- a/app/app.php
+++ b/app/app.php
@@ -23,9 +23,9 @@ if (isset($_GET["calendar"])) {
     if (strpos($fbCal, 'webcal') === 0) {
         $fbCal = substr_replace($fbCal, "http", 0, strlen('webcal'));
     }
-    if (strpos($fbCal, 'http://' !== 0)) {
+    if (strpos($fbCal, 'http://www.facebook.com/ical/' !== 0) {
         http_response_code(400);
-        die("Not a url");
+        die("Not a valid Facebook calendar url")
     }
     $content = @file_get_contents($fbCal);
 

--- a/app/app.php
+++ b/app/app.php
@@ -23,7 +23,7 @@ if (isset($_GET["calendar"])) {
     if (strpos($fbCal, 'webcal') === 0) {
         $fbCal = substr_replace($fbCal, "http", 0, strlen('webcal'));
     }
-    if (strpos($fbCal, 'http://www.facebook.com/ical/' !== 0) {
+    if (strpos($fbCal, 'http://www.facebook.com/ical/' !== 0)) {
         http_response_code(400);
         die("Not a valid Facebook calendar url")
     }

--- a/app/app.php
+++ b/app/app.php
@@ -23,7 +23,7 @@ if (isset($_GET["calendar"])) {
     if (strpos($fbCal, 'webcal') === 0) {
         $fbCal = substr_replace($fbCal, "http", 0, strlen('webcal'));
     }
-    if (strpos($fbCal, 'http://www.facebook.com/ical/' !== 0)) {
+    if (strpos($fbCal, 'http://www.facebook.com/ical/') !== 0) {
         http_response_code(400);
         die("Not a valid Facebook calendar url");
     }

--- a/app/app.php
+++ b/app/app.php
@@ -25,7 +25,7 @@ if (isset($_GET["calendar"])) {
     }
     if (strpos($fbCal, 'http://www.facebook.com/ical/' !== 0)) {
         http_response_code(400);
-        die("Not a valid Facebook calendar url")
+        die("Not a valid Facebook calendar url");
     }
     $content = @file_get_contents($fbCal);
 

--- a/app/app.php
+++ b/app/app.php
@@ -23,7 +23,7 @@ if (isset($_GET["calendar"])) {
     if (strpos($fbCal, 'webcal') === 0) {
         $fbCal = substr_replace($fbCal, "http", 0, strlen('webcal'));
     }
-    if (strpos($fbCal, 'http://www.facebook.com/ical/') !== 0) {
+    if (!preg_match('#^https?://www\.facebook\.com/ical/#', $fbCal)) {
         http_response_code(400);
         die("Not a valid Facebook calendar url");
     }


### PR DESCRIPTION
Protect this script to be used as a web proxy
http://eventcal.flown.io/?calendar=http%3A%2F%2Fgoogle.com